### PR TITLE
Change how user registration works

### DIFF
--- a/algebras/user/src/main/scala/pms/algebra/user/UserAccountAlgebra.scala
+++ b/algebras/user/src/main/scala/pms/algebra/user/UserAccountAlgebra.scala
@@ -22,7 +22,7 @@ trait UserAccountAlgebra[F[_]] {
 
   protected[user] def registrationStep1Impl(inv: UserInvitation): F[UserRegistrationToken]
 
-  def registrationStep2(token: UserRegistrationToken): F[User]
+  def registrationStep2(token: UserRegistrationToken, pw: PlainTextPassword): F[User]
 
   def resetPasswordStep1(email: Email): F[PasswordResetToken]
 

--- a/algebras/user/src/main/scala/pms/algebra/user/UserAccountAlgebra.scala
+++ b/algebras/user/src/main/scala/pms/algebra/user/UserAccountAlgebra.scala
@@ -15,12 +15,12 @@ trait UserAccountAlgebra[F[_]] {
   protected def authAlgebra:         UserAuthAlgebra[F]
 
   final def registrationStep1(
-    reg: UserRegistration,
+    inv: UserInvitation,
   )(
     implicit auth: AuthCtx,
-  ): F[UserRegistrationToken] = authAlgebra.authorizeGTERole(reg.role)(registrationStep1Impl(reg))
+  ): F[UserRegistrationToken] = authAlgebra.authorizeGTERole(inv.role)(registrationStep1Impl(inv))
 
-  protected[user] def registrationStep1Impl(reg: UserRegistration): F[UserRegistrationToken]
+  protected[user] def registrationStep1Impl(inv: UserInvitation): F[UserRegistrationToken]
 
   def registrationStep2(token: UserRegistrationToken): F[User]
 

--- a/algebras/user/src/main/scala/pms/algebra/user/UserAccountAlgebra.scala
+++ b/algebras/user/src/main/scala/pms/algebra/user/UserAccountAlgebra.scala
@@ -18,11 +18,11 @@ trait UserAccountAlgebra[F[_]] {
     inv: UserInvitation,
   )(
     implicit auth: AuthCtx,
-  ): F[UserRegistrationToken] = authAlgebra.authorizeGTERole(inv.role)(registrationStep1Impl(inv))
+  ): F[UserInviteToken] = authAlgebra.authorizeGTERole(inv.role)(registrationStep1Impl(inv))
 
-  protected[user] def registrationStep1Impl(inv: UserInvitation): F[UserRegistrationToken]
+  protected[user] def registrationStep1Impl(inv: UserInvitation): F[UserInviteToken]
 
-  def registrationStep2(token: UserRegistrationToken, pw: PlainTextPassword): F[User]
+  def registrationStep2(token: UserInviteToken, pw: PlainTextPassword): F[User]
 
   def resetPasswordStep1(email: Email): F[PasswordResetToken]
 

--- a/algebras/user/src/main/scala/pms/algebra/user/UserAccountBootstrapAlgebra.scala
+++ b/algebras/user/src/main/scala/pms/algebra/user/UserAccountBootstrapAlgebra.scala
@@ -12,7 +12,7 @@ final class UserAccountBootstrapAlgebra[F[_]] private (
   private val uca: UserAccountAlgebra[F],
 ) {
 
-  def bootstrapUser(inv: UserInvitation): F[UserRegistrationToken] =
+  def bootstrapUser(inv: UserInvitation): F[UserInviteToken] =
     uca.registrationStep1Impl(inv)
 }
 

--- a/algebras/user/src/main/scala/pms/algebra/user/UserAccountBootstrapAlgebra.scala
+++ b/algebras/user/src/main/scala/pms/algebra/user/UserAccountBootstrapAlgebra.scala
@@ -12,8 +12,8 @@ final class UserAccountBootstrapAlgebra[F[_]] private (
   private val uca: UserAccountAlgebra[F],
 ) {
 
-  def bootstrapUser(reg: UserRegistration): F[UserRegistrationToken] =
-    uca.registrationStep1Impl(reg)
+  def bootstrapUser(inv: UserInvitation): F[UserRegistrationToken] =
+    uca.registrationStep1Impl(inv)
 }
 
 object UserAccountBootstrapAlgebra {

--- a/algebras/user/src/main/scala/pms/algebra/user/UserInvitation.scala
+++ b/algebras/user/src/main/scala/pms/algebra/user/UserInvitation.scala
@@ -10,6 +10,5 @@ import pms.core._
   */
 final case class UserInvitation(
   email: Email,
-  pw:    PlainTextPassword,
   role:  UserRole,
 )

--- a/algebras/user/src/main/scala/pms/algebra/user/UserInvitation.scala
+++ b/algebras/user/src/main/scala/pms/algebra/user/UserInvitation.scala
@@ -8,7 +8,7 @@ import pms.core._
   * @since 26 Jun 2018
   *
   */
-final case class UserRegistration(
+final case class UserInvitation(
   email: Email,
   pw:    PlainTextPassword,
   role:  UserRole,

--- a/algebras/user/src/main/scala/pms/algebra/user/impl/UserAlgebraImpl.scala
+++ b/algebras/user/src/main/scala/pms/algebra/user/impl/UserAlgebraImpl.scala
@@ -50,7 +50,7 @@ final private[user] class UserAlgebraImpl[F[_]] private (
 
   override protected[user] def registrationStep1Impl(
     inv: UserInvitation,
-  ): F[UserRegistrationToken] =
+  ): F[UserInviteToken] =
     for {
       token <- UserCrypto.generateToken(F).map(UserRegistrationToken.spook)
       toInsert = UserInvitationSQL.UserInvitationRepr(
@@ -61,7 +61,7 @@ final private[user] class UserAlgebraImpl[F[_]] private (
       _ <- UserInvitationSQL.insert(toInsert).transact(transactor)
     } yield token
 
-  override def registrationStep2(token: UserRegistrationToken, pw: PlainTextPassword): F[User] = {
+  override def registrationStep2(token: UserInviteToken, pw: PlainTextPassword): F[User] = {
     val cio: ConnectionIO[User] = for {
       invite <- UserInvitationSQL.findByToken(token).flatMap { opt =>
         opt.liftTo[ConnectionIO](new RuntimeException("No user invitation found"))

--- a/algebras/user/src/main/scala/pms/algebra/user/impl/UserAlgebraImpl.scala
+++ b/algebras/user/src/main/scala/pms/algebra/user/impl/UserAlgebraImpl.scala
@@ -61,13 +61,14 @@ final private[user] class UserAlgebraImpl[F[_]] private (
       _ <- UserInvitationSQL.insert(toInsert).transact(transactor)
     } yield token
 
-  override def registrationStep2(token: UserRegistrationToken): F[User] =
-    updateRegToken(token) //FIXME: rework this to actually make sense.
-      .transact(transactor)
-      .map {
-        case Some(value) => value
-        case None        => throw new Exception("User not found") //FIXME: flatMap + effect
-      }
+  override def registrationStep2(token: UserRegistrationToken, pw: PlainTextPassword): F[User] =
+    ???
+//    updateRegToken(token) //FIXME: rework this to actually make sense.
+//      .transact(transactor)
+//      .map {
+//        case Some(value) => value
+//        case None        => throw new Exception("User not found") //FIXME: flatMap + effect
+//      }
 
   override def resetPasswordStep1(email: Email): F[PasswordResetToken] =
     for {

--- a/algebras/user/src/main/scala/pms/algebra/user/impl/UserAlgebraImpl.scala
+++ b/algebras/user/src/main/scala/pms/algebra/user/impl/UserAlgebraImpl.scala
@@ -49,12 +49,12 @@ final private[user] class UserAlgebraImpl[F[_]] private (
     updateRole(id, newRole).transact(transactor).map(_ => ())
 
   override protected[user] def registrationStep1Impl(
-    reg: UserRegistration,
+    inv: UserInvitation,
   ): F[UserRegistrationToken] =
     for {
       token      <- UserCrypto.generateToken(F)
-      scryptHash <- UserCrypto.hashPWWithBcrypt(reg.pw)(F)
-      repr = UserRepr(email = reg.email, pw = scryptHash, role = reg.role)
+      scryptHash <- UserCrypto.hashPWWithBcrypt(inv.pw)(F)
+      repr = UserRepr(email = inv.email, pw = scryptHash, role = inv.role)
       _ <- insert(repr, UserRegistrationToken(token)).transact(transactor)
     } yield UserRegistrationToken(token)
 

--- a/algebras/user/src/main/scala/pms/algebra/user/impl/UserAlgebraMetas.scala
+++ b/algebras/user/src/main/scala/pms/algebra/user/impl/UserAlgebraMetas.scala
@@ -1,0 +1,44 @@
+package pms.algebra.user.impl
+
+import doobie._
+import doobie.implicits._
+import cats.implicits._
+import pms.algebra.user._
+import pms.core._
+import pms.effects._
+
+/**
+  *
+  * @author Lorand Szakacs, https://github.com/lorandszakacs
+  * @since 24 Apr 2019
+  *
+  */
+private[impl] object UserAlgebraMetas {
+
+  implicit val userIDMeta: Meta[UserID] = Meta[Long].imap(UserID.spook)(UserID.despook)
+
+  implicit val authenticationTokenMeta: Meta[AuthenticationToken] =
+    Meta[String].imap(AuthenticationToken.spook)(AuthenticationToken.despook)
+
+  implicit val userRegistrationTokenMeta: Meta[UserRegistrationToken] =
+    Meta[String].imap(UserRegistrationToken.spook)(UserRegistrationToken.despook)
+
+  implicit val passwordResetTokenMeta: Meta[PasswordResetToken] =
+    Meta[String].imap(PasswordResetToken.spook)(PasswordResetToken.despook)
+
+  implicit val emailMeta: Meta[Email] =
+    Meta[String].imap(Email.apply(_).unsafeGet())(_.plainTextEmail)
+
+  implicit val pwdMeta: Meta[PlainTextPassword] =
+    Meta[String].imap(PlainTextPassword.apply(_).unsafeGet())(_.plainText)
+
+  implicit val userRoleMeta: Meta[UserRole] =
+    Meta[String].imap(UserRole.fromName(_).unsafeGet())(_.toString)
+
+  implicit val userComposite: Read[User] =
+    Read[(UserID, Email, UserRole)]
+      .imap((t: (UserID, Email, UserRole)) => User(t._1, t._2, t._3))((u: User) => (u.id, u.email, u.role))
+
+
+
+}

--- a/algebras/user/src/main/scala/pms/algebra/user/impl/UserAlgebraMetas.scala
+++ b/algebras/user/src/main/scala/pms/algebra/user/impl/UserAlgebraMetas.scala
@@ -1,7 +1,6 @@
 package pms.algebra.user.impl
 
 import doobie._
-import doobie.implicits._
 import cats.implicits._
 import pms.algebra.user._
 import pms.core._

--- a/algebras/user/src/main/scala/pms/algebra/user/impl/UserAlgebraMetas.scala
+++ b/algebras/user/src/main/scala/pms/algebra/user/impl/UserAlgebraMetas.scala
@@ -19,7 +19,7 @@ private[impl] object UserAlgebraMetas {
   implicit val authenticationTokenMeta: Meta[AuthenticationToken] =
     Meta[String].imap(AuthenticationToken.spook)(AuthenticationToken.despook)
 
-  implicit val userRegistrationTokenMeta: Meta[UserRegistrationToken] =
+  implicit val userRegistrationTokenMeta: Meta[UserInviteToken] =
     Meta[String].imap(UserRegistrationToken.spook)(UserRegistrationToken.despook)
 
   implicit val passwordResetTokenMeta: Meta[PasswordResetToken] =

--- a/algebras/user/src/main/scala/pms/algebra/user/impl/UserAlgebraSQL.scala
+++ b/algebras/user/src/main/scala/pms/algebra/user/impl/UserAlgebraSQL.scala
@@ -5,7 +5,6 @@ import doobie.implicits._
 import cats.implicits._
 import pms.algebra.user._
 import pms.core._
-import pms.effects._
 
 /**
   *

--- a/algebras/user/src/main/scala/pms/algebra/user/impl/UserAlgebraSQL.scala
+++ b/algebras/user/src/main/scala/pms/algebra/user/impl/UserAlgebraSQL.scala
@@ -16,43 +16,19 @@ import pms.effects._
   */
 private[impl] object UserAlgebraSQL {
 
+  import UserAlgebraMetas._
+
   private[impl] case class UserRepr(
     email: Email,
     pw:    UserCrypto.BcryptPW,
     role:  UserRole,
   )
 
-  /*_*/
-  implicit val userIDMeta: Meta[UserID] = Meta[Long].imap(UserID.spook)(UserID.despook)
-
-  implicit val authenticationTokenMeta: Meta[AuthenticationToken] =
-    Meta[String].imap(AuthenticationToken.spook)(AuthenticationToken.despook)
-
-  implicit val userRegistrationTokenMeta: Meta[UserRegistrationToken] =
-    Meta[String].imap(UserRegistrationToken.spook)(UserRegistrationToken.despook)
-
-  implicit val passwordResetTokenMeta: Meta[PasswordResetToken] =
-    Meta[String].imap(PasswordResetToken.spook)(PasswordResetToken.despook)
-
-  implicit val emailMeta: Meta[Email] =
-    Meta[String].imap(Email.apply(_).unsafeGet())(_.plainTextEmail)
-
-  implicit val pwdMeta: Meta[PlainTextPassword] =
-    Meta[String].imap(PlainTextPassword.apply(_).unsafeGet())(_.plainText)
-
-  implicit val userRoleMeta: Meta[UserRole] =
-    Meta[String].imap(UserRole.fromName(_).unsafeGet())(_.toString)
-
-  implicit val userComposite: Read[User] =
-    Read[(UserID, Email, UserRole)]
-      .imap((t: (UserID, Email, UserRole)) => User(t._1, t._2, t._3))((u: User) => (u.id, u.email, u.role))
-
   implicit val userReprComposite: Read[UserRepr] =
     Read[(Email, String, UserRole)]
       .imap((t: (Email, String, UserRole)) => UserRepr(t._1, UserCrypto.BcryptPW(t._2), t._3))(
         (u: UserRepr) => (u.email, u.pw.toString, u.role),
       )
-  /*_*/
 
   def updateRole(id: UserID, role: UserRole): ConnectionIO[Int] =
     sql"""UPDATE users SET role=$role WHERE id=$id""".update.run

--- a/algebras/user/src/main/scala/pms/algebra/user/impl/UserAlgebraSQL.scala
+++ b/algebras/user/src/main/scala/pms/algebra/user/impl/UserAlgebraSQL.scala
@@ -1,6 +1,5 @@
 package pms.algebra.user.impl
 
-import busymachines.core.InvalidInputFailure
 import doobie._
 import doobie.implicits._
 import cats.implicits._
@@ -63,9 +62,10 @@ private[impl] object UserAlgebraSQL {
   def findByPwdToken(token: PasswordResetToken): ConnectionIO[Option[User]] =
     sql"""SELECT id, email, role FROM users WHERE passwordReset=$token""".query[User].option
 
-  def insert(repr: UserRepr, token: UserRegistrationToken): ConnectionIO[Long] = {
-    sql"""INSERT INTO users(email, password, role, registration) VALUES (${repr.email}, ${repr.pw.toString}, ${repr.role}, $token)""".update
+  def insert(repr: UserRepr): ConnectionIO[UserID] = {
+    sql"""INSERT INTO users(email, password, role) VALUES (${repr.email}, ${repr.pw.toString}, ${repr.role})""".update
       .withUniqueGeneratedKeys[Long]("id")
+      .map(UserID.spook)
   }
 
   def insertAuthenticationToken(id: UserID, token: AuthenticationToken): ConnectionIO[Long] =

--- a/algebras/user/src/main/scala/pms/algebra/user/impl/UserAlgebraSQL.scala
+++ b/algebras/user/src/main/scala/pms/algebra/user/impl/UserAlgebraSQL.scala
@@ -31,7 +31,7 @@ private[impl] object UserAlgebraSQL {
   def updateRole(id: UserID, role: UserRole): ConnectionIO[Int] =
     sql"""UPDATE users SET role=$role WHERE id=$id""".update.run
 
-  def updateRegistrationToken(id: UserID, token: UserRegistrationToken): ConnectionIO[Int] =
+  def updateRegistrationToken(id: UserID, token: UserInviteToken): ConnectionIO[Int] =
     sql"""UPDATE users SET registration=$token WHERE id=$id""".update.run
 
   def updatePasswordToken(id: UserID, token: PasswordResetToken): ConnectionIO[Int] =
@@ -55,7 +55,7 @@ private[impl] object UserAlgebraSQL {
   def findByAuthToken(token: AuthenticationToken): ConnectionIO[Option[Long]] =
     sql"""SELECT userId FROM authentications WHERE token=$token""".query[Long].option
 
-  def findByRegToken(token: UserRegistrationToken): ConnectionIO[Option[User]] =
+  def findByRegToken(token: UserInviteToken): ConnectionIO[Option[User]] =
     sql"""SELECT id, email, role FROM users WHERE registration=$token""".query[User].option
 
   def findByPwdToken(token: PasswordResetToken): ConnectionIO[Option[User]] =

--- a/algebras/user/src/main/scala/pms/algebra/user/impl/UserAlgebraSQL.scala
+++ b/algebras/user/src/main/scala/pms/algebra/user/impl/UserAlgebraSQL.scala
@@ -80,16 +80,6 @@ private[impl] object UserAlgebraSQL {
       }
     } yield user
 
-  //FIXME: instead of None when registration token doesn't exist, return an
-  //FIXME: "InvalidRegistrationToken" or something.
-  def updateRegToken(token: UserRegistrationToken): ConnectionIO[Option[User]] = {
-    for {
-      userOpt <- findByRegToken(token)
-      user    <- userOpt.liftTo[ConnectionIO](InvalidInputFailure("Invalid registration token"))
-      _       <- updateRegistrationToken(user.id, token)
-    } yield Option(user)
-  }
-
   def insertToken(findUser: => ConnectionIO[Option[User]], token: AuthenticationToken): ConnectionIO[Option[User]] =
     for {
       user <- findUser

--- a/algebras/user/src/main/scala/pms/algebra/user/impl/UserCrypto.scala
+++ b/algebras/user/src/main/scala/pms/algebra/user/impl/UserCrypto.scala
@@ -25,6 +25,14 @@ private[impl] object UserCrypto {
   type BcryptPW = PasswordHash[BCrypt]
   def BcryptPW(pt: String): BcryptPW = PasswordHash[BCrypt](pt)
 
+  //FIXME: modify this to be able to tell it to generate one of the three specific tokens
+  /**
+    * Ideally, I'd want to write something like this:
+    * {{{
+    *   UserCrypto.generateToken[F, AuthenticationToken]
+    * }}}
+    *
+    */
   private[impl] def generateToken[F[_]: Sync]: F[String] =
     for {
       key    <- HMACSHA256.generateKey[F]

--- a/algebras/user/src/main/scala/pms/algebra/user/impl/UserInvitationSQL.scala
+++ b/algebras/user/src/main/scala/pms/algebra/user/impl/UserInvitationSQL.scala
@@ -1,0 +1,21 @@
+package pms.algebra.user.impl
+
+import doobie._
+import pms.algebra.user._
+import pms.core._
+
+/**
+  *
+  * @author Lorand Szakacs, https://github.com/lorandszakacs
+  * @since 24 Apr 2019
+  *
+  */
+private[impl] object UserInvitationSQL {
+  final case class UserInvitationRepr(
+    email:           Email,
+    role:            UserRole,
+    invitationToken: UserRegistrationToken,
+  )
+  def insert(inv: UserInvitationRepr): ConnectionIO[Unit] = ???
+
+}

--- a/algebras/user/src/main/scala/pms/algebra/user/impl/UserInvitationSQL.scala
+++ b/algebras/user/src/main/scala/pms/algebra/user/impl/UserInvitationSQL.scala
@@ -18,4 +18,8 @@ private[impl] object UserInvitationSQL {
   )
   def insert(inv: UserInvitationRepr): ConnectionIO[Unit] = ???
 
+  def findByToken(tok: UserRegistrationToken): ConnectionIO[Option[UserInvitationRepr]] = ???
+
+  def deleteByToken(tok: UserRegistrationToken): ConnectionIO[Unit] = ???
+
 }

--- a/algebras/user/src/main/scala/pms/algebra/user/impl/UserInvitationSQL.scala
+++ b/algebras/user/src/main/scala/pms/algebra/user/impl/UserInvitationSQL.scala
@@ -19,24 +19,23 @@ private[impl] object UserInvitationSQL {
   /*_*/
 
   final case class UserInvitationRepr(
-    email:           Email,
-    role:            UserRole,
-    invitationToken: UserRegistrationToken,
+                                       email:           Email,
+                                       role:            UserRole,
+                                       invitationToken: UserInviteToken,
   )
 
   implicit val userReprComposite: Read[UserInvitationRepr] =
-    Read[(Email, UserRole, UserRegistrationToken)]
-      .map((t: (Email, UserRole, UserRegistrationToken)) => UserInvitationRepr.tupled.apply(t): UserInvitationRepr)
+    Read[(Email, UserRole, UserInviteToken)]
+      .map((t: (Email, UserRole, UserInviteToken)) => UserInvitationRepr.tupled.apply(t): UserInvitationRepr)
 
   def insert(repr: UserInvitationRepr): ConnectionIO[Unit] =
     sql"""INSERT INTO user_invitation(email, role, registration) VALUES (${repr.email}, ${repr.role}, ${repr.invitationToken})""".update.run.void
 
-  def findByToken(token: UserRegistrationToken): ConnectionIO[Option[UserInvitationRepr]] =
+  def findByToken(token: UserInviteToken): ConnectionIO[Option[UserInvitationRepr]] =
     sql"""SELECT email, role, registration FROM user_invitation WHERE registration=$token"""
       .query[UserInvitationRepr]
       .option
 
-  def deleteByToken(tok: UserRegistrationToken): ConnectionIO[Unit] =
-    sql"""DELETE * FROM user_invitation WHERE registration=$tok""".update.run.void
-
+  def deleteByToken(tok: UserInviteToken): ConnectionIO[Unit] =
+    sql"""DELETE FROM user_invitation WHERE registration=$tok""".update.run.void
 }

--- a/algebras/user/src/main/scala/pms/algebra/user/package.scala
+++ b/algebras/user/src/main/scala/pms/algebra/user/package.scala
@@ -13,7 +13,7 @@ package object user {
   type UserID = UserID.Type
 
   object UserRegistrationToken extends PhantomType[String]
-  type UserRegistrationToken = UserRegistrationToken.Type
+  type UserInviteToken = UserRegistrationToken.Type
 
   object PasswordResetToken extends PhantomType[String]
   type PasswordResetToken = PasswordResetToken.Type

--- a/pms-utils/db-config/src/main/resources/db/migration/V0_0_3__create_user_invitation_table.sql
+++ b/pms-utils/db-config/src/main/resources/db/migration/V0_0_3__create_user_invitation_table.sql
@@ -1,0 +1,11 @@
+ALTER TABLE users
+DROP COLUMN registration;
+
+CREATE TABLE user_invitation (
+  email varchar(255) NOT NULL,
+  role varchar(255) NOT NULL,
+  registration varchar(255) NOT NULL UNIQUE,
+  PRIMARY KEY (email)
+);
+
+CREATE UNIQUE INDEX registration_idx ON user_invitation (registration);

--- a/server-bootstrap/src/main/scala/pms/server/bootstrap/ServerBootstrapAlgebra.scala
+++ b/server-bootstrap/src/main/scala/pms/server/bootstrap/ServerBootstrapAlgebra.scala
@@ -34,7 +34,7 @@ sealed abstract class ServerBootstrapAlgebra[F[_]](
   final def bootStrapUser(inv: UserInvitation, pw: PlainTextPassword): F[User] =
     for {
       token <- uba.bootstrapUser(inv)
-      user  <- uca.registrationStep2(token)
+      user  <- uca.registrationStep2(token, pw)
       _ <- logger.info(
         s"BOOTSTRAP — inserting user: role=${inv.role.productPrefix} email=${inv.email.plainTextEmail} pw=${pw.plainText}",
       )

--- a/server-bootstrap/src/main/scala/pms/server/bootstrap/ServerBootstrapAlgebra.scala
+++ b/server-bootstrap/src/main/scala/pms/server/bootstrap/ServerBootstrapAlgebra.scala
@@ -29,14 +29,14 @@ sealed abstract class ServerBootstrapAlgebra[F[_]](
     bootStrapUser(email, pw, UserRole.SuperAdmin)
 
   final def bootStrapUser(email: Email, pw: PlainTextPassword, role: UserRole): F[User] =
-    this.bootStrapUser(UserRegistration(email, pw, role))
+    this.bootStrapUser(UserInvitation(email, pw, role))
 
-  final def bootStrapUser(reg: UserRegistration): F[User] =
+  final def bootStrapUser(inv: UserInvitation): F[User] =
     for {
-      token <- uba.bootstrapUser(reg)
+      token <- uba.bootstrapUser(inv)
       user  <- uca.registrationStep2(token)
       _ <- logger.info(
-        s"BOOTSTRAP — inserting user: role=${reg.role.productPrefix} email=${reg.email.plainTextEmail} pw=${reg.pw.plainText}",
+        s"BOOTSTRAP — inserting user: role=${inv.role.productPrefix} email=${inv.email.plainTextEmail} pw=${inv.pw.plainText}",
       )
     } yield user
 }

--- a/server-bootstrap/src/main/scala/pms/server/bootstrap/ServerBootstrapAlgebra.scala
+++ b/server-bootstrap/src/main/scala/pms/server/bootstrap/ServerBootstrapAlgebra.scala
@@ -29,14 +29,14 @@ sealed abstract class ServerBootstrapAlgebra[F[_]](
     bootStrapUser(email, pw, UserRole.SuperAdmin)
 
   final def bootStrapUser(email: Email, pw: PlainTextPassword, role: UserRole): F[User] =
-    this.bootStrapUser(UserInvitation(email, pw, role))
+    this.bootStrapUser(UserInvitation(email, role), pw)
 
-  final def bootStrapUser(inv: UserInvitation): F[User] =
+  final def bootStrapUser(inv: UserInvitation, pw: PlainTextPassword): F[User] =
     for {
       token <- uba.bootstrapUser(inv)
       user  <- uca.registrationStep2(token)
       _ <- logger.info(
-        s"BOOTSTRAP — inserting user: role=${inv.role.productPrefix} email=${inv.email.plainTextEmail} pw=${inv.pw.plainText}",
+        s"BOOTSTRAP — inserting user: role=${inv.role.productPrefix} email=${inv.email.plainTextEmail} pw=${pw.plainText}",
       )
     } yield user
 }

--- a/services/user/src/main/scala/pms/service/user/UserAccountService.scala
+++ b/services/user/src/main/scala/pms/service/user/UserAccountService.scala
@@ -37,9 +37,9 @@ final class UserAccountService[F[_]] private (
       }
     } yield ()
 
-  def registrationStep2(token: UserRegistrationToken): F[User] =
+  def registrationStep2(conf: UserConfirmation): F[User] =
     for {
-      user <- userAccount.registrationStep2(token)
+      user <- userAccount.registrationStep2(conf.invitationToken, conf.plainTextPassword)
     } yield user
 
   def resetPasswordStep1(email: Email): F[Unit] =

--- a/services/user/src/main/scala/pms/service/user/UserAccountService.scala
+++ b/services/user/src/main/scala/pms/service/user/UserAccountService.scala
@@ -23,17 +23,17 @@ final class UserAccountService[F[_]] private (
   implicit private val F: Concurrent[F],
 ) {
 
-  def registrationStep1(reg: UserRegistration)(implicit authCtx: AuthCtx): F[Unit] =
+  def registrationStep1(inv: UserInvitation)(implicit authCtx: AuthCtx): F[Unit] =
     for {
-      regToken <- userAccount.registrationStep1(reg)
+      regToken <- userAccount.registrationStep1(inv)
       _ <- forkAndForget {
         emailAlgebra.sendEmail(
-          to      = reg.email,
+          to = inv.email,
           //FIXME: resolve this data from an email content algebra or something
-          subject = "User Registration on Pure Movie Server",
+          subject = s"You have been invited to join Pure Movie Server as a :${inv.role.productPrefix}",
           //FIXME: resolve this data from an email content algebra or something
           content = s"Please click this link to finish registration: [link_to_frontend]/$regToken",
-        )//FIXME: do recoverWith and at least delete the user registration if sending email fails.
+        ) //FIXME: do recoverWith and at least delete the user registration if sending email fails.
       }
     } yield ()
 

--- a/services/user/src/main/scala/pms/service/user/UserConfirmation.scala
+++ b/services/user/src/main/scala/pms/service/user/UserConfirmation.scala
@@ -1,0 +1,15 @@
+package pms.service.user
+
+import pms.algebra.user.UserRegistrationToken
+import pms.core.PlainTextPassword
+
+/**
+  *
+  * @author Lorand Szakacs, https://github.com/lorandszakacs
+  * @since 24 Apr 2019
+  *
+  */
+final case class UserConfirmation(
+  invitationToken:   UserRegistrationToken,
+  plainTextPassword: PlainTextPassword,
+)

--- a/services/user/src/main/scala/pms/service/user/UserConfirmation.scala
+++ b/services/user/src/main/scala/pms/service/user/UserConfirmation.scala
@@ -1,6 +1,6 @@
 package pms.service.user
 
-import pms.algebra.user.UserRegistrationToken
+import pms.algebra.user.UserInviteToken
 import pms.core.PlainTextPassword
 
 /**
@@ -10,6 +10,6 @@ import pms.core.PlainTextPassword
   *
   */
 final case class UserConfirmation(
-  invitationToken:   UserRegistrationToken,
-  plainTextPassword: PlainTextPassword,
+                                   invitationToken:   UserInviteToken,
+                                   plainTextPassword: PlainTextPassword,
 )

--- a/services/user/src/main/scala/pms/service/user/rest/UserAccountRoutes.scala
+++ b/services/user/src/main/scala/pms/service/user/rest/UserAccountRoutes.scala
@@ -30,7 +30,7 @@ final class UserAccountRoutes[F[_]](
   private val userRegistrationStep1Routes: AuthCtxRoutes[F] = AuthCtxRoutes[F] {
     case (req @ POST -> Root / "user_registration") as user =>
       for {
-        reg  <- req.as[UserRegistration]
+        reg  <- req.as[UserInvitation]
         _    <- userService.registrationStep1(reg)(user)
         resp <- Created()
       } yield resp

--- a/services/user/src/main/scala/pms/service/user/rest/UserAccountRoutes.scala
+++ b/services/user/src/main/scala/pms/service/user/rest/UserAccountRoutes.scala
@@ -24,8 +24,6 @@ final class UserAccountRoutes[F[_]](
   implicit val F: Async[F],
 ) extends Http4sDsl[F] with UserRoutesJSON {
 
-  private object RegistrationTokenMatcher extends QueryParamDecoderMatcher[String]("registrationToken")
-
   //FIXME: rename this to UserInvitation, all the way down
   private val userRegistrationStep1Routes: AuthCtxRoutes[F] = AuthCtxRoutes[F] {
     case (req @ POST -> Root / "user_registration") as user =>
@@ -37,9 +35,10 @@ final class UserAccountRoutes[F[_]](
   }
 
   private val userRegistrationStep2Routes: HttpRoutes[F] = HttpRoutes.of[F] {
-    case PUT -> Root / "user_registration" / "confirmation" :? RegistrationTokenMatcher(token) =>
+    case req @ PUT -> Root / "user_registration" / "confirmation" =>
       for {
-        user <- userService.registrationStep2(UserRegistrationToken(token))
+        conf <- req.as[UserConfirmation]
+        user <- userService.registrationStep2(conf)
         resp <- Ok(user)
       } yield resp
   }

--- a/services/user/src/main/scala/pms/service/user/rest/UserRoutesJSON.scala
+++ b/services/user/src/main/scala/pms/service/user/rest/UserRoutesJSON.scala
@@ -37,7 +37,15 @@ trait UserRoutesJSON extends PMSJson {
     decode = Decoder.apply[String].map(AuthenticationToken.spook),
   )
 
+  //FIXME: derive automatically
+  implicit val invitationTokenCirceCodec: Codec[UserRegistrationToken] = Codec.instance(
+    encode = Encoder.apply[String].contramap(UserRegistrationToken.despook),
+    decode = Decoder.apply[String].map(UserRegistrationToken.spook),
+  )
+
   implicit val userInvitationCirceCodec: Codec[UserInvitation] = derive.codec[UserInvitation]
+
+  implicit val userConfirmationCirceCodec: Codec[UserConfirmation] = derive.codec[UserConfirmation]
 
   implicit val userCirceCodec: Codec[User] = derive.codec[User]
 

--- a/services/user/src/main/scala/pms/service/user/rest/UserRoutesJSON.scala
+++ b/services/user/src/main/scala/pms/service/user/rest/UserRoutesJSON.scala
@@ -37,7 +37,7 @@ trait UserRoutesJSON extends PMSJson {
     decode = Decoder.apply[String].map(AuthenticationToken.spook),
   )
 
-  implicit val userRegistrationCirceCodec: Codec[UserRegistration] = derive.codec[UserRegistration]
+  implicit val userInvitationCirceCodec: Codec[UserInvitation] = derive.codec[UserInvitation]
 
   implicit val userCirceCodec: Codec[User] = derive.codec[User]
 

--- a/services/user/src/main/scala/pms/service/user/rest/UserRoutesJSON.scala
+++ b/services/user/src/main/scala/pms/service/user/rest/UserRoutesJSON.scala
@@ -38,7 +38,7 @@ trait UserRoutesJSON extends PMSJson {
   )
 
   //FIXME: derive automatically
-  implicit val invitationTokenCirceCodec: Codec[UserRegistrationToken] = Codec.instance(
+  implicit val invitationTokenCirceCodec: Codec[UserInviteToken] = Codec.instance(
     encode = Encoder.apply[String].contramap(UserRegistrationToken.despook),
     decode = Decoder.apply[String].map(UserRegistrationToken.spook),
   )


### PR DESCRIPTION
Problem:
Initial user registration made little sense. Use who sent out invite also provided password — bad idea. And also, the SQL table was mangled together, and it made little sense.

How we fixed it:
- [x] password no longer provided in registration step 1 + store invites in separate table
- [x] user instead of providing only registration token in URL, now provides both registration token, and desired password in body of request for registration step 2.